### PR TITLE
fix: 공유 컴포넌트 props 추가

### DIFF
--- a/components/form/ShareOverlay.tsx
+++ b/components/form/ShareOverlay.tsx
@@ -98,6 +98,8 @@ const ShareOverlay = ({ animal, imgSrc }: { animal: string | undefined; imgSrc?:
           isOpen={isSNSShareVisible}
           onClose={handleShareClose}
           imageUrl={imgSrc}
+          title="제가 찾은 해양 생물이에요!"
+          value="저희와 함께 해양 생물을 찾아보아요!"
         />
       )}
     </React.Fragment>

--- a/components/post/PostDialog.tsx
+++ b/components/post/PostDialog.tsx
@@ -385,6 +385,8 @@ export default function PostDialog({
         isOpen={isSNSShareVisible}
         onClose={handleShareClose}
         imageUrl={imageInfoList[0] ?? '/test.jpeg'} //TODO: fallback url
+        title={author + '님이 찾은 해양 생물이에요!'}
+        value="다른 해양 생물도 보러 가실래요?"
       />
       <ConfirmDialog
         open={openConfirm}

--- a/components/share/SNSSharingComponent.tsx
+++ b/components/share/SNSSharingComponent.tsx
@@ -20,7 +20,7 @@ const loadKakaoLinkScript = () => {
   document.head.appendChild(script)
 }
 
-const SNSSharingComponent = ({ isOpen, onClose, imageUrl }: any) => {
+const SNSSharingComponent = ({ isOpen, onClose, imageUrl, title, value }: any) => {
   React.useEffect(() => {
     loadKakaoLinkScript()
   }, [])
@@ -69,15 +69,14 @@ const SNSSharingComponent = ({ isOpen, onClose, imageUrl }: any) => {
       window.Kakao.init(process.env.NEXT_PUBLIC_JAVASCRIPT_KEY) // JS Key
       setKakaoInitialized(true)
     }
-    const staticWebUrl = process.env.NEXT_PUBLIC_WEBURL // 본인 URL
+    const staticWebUrl = process.env.NEXT_PUBLIC_WEBURL
 
     window.Kakao.Share.sendDefault({
       objectType: 'feed',
       content: {
-        title: '제가 찾은 해양 생물이에요!', // 제목
-        description: '저희와 함께 해양 생물을 찾아보아요!', // 설명
-        // imageUrl: imgUrl, // 공유할 이미지 URL
-        imageUrl: 'https://ifh.cc/g/xBq9oj.webp',
+        title: title, // 제목
+        description: value, // 설명
+        imageUrl: imageUrl, // 이미지
         link: {
           mobileWebUrl: staticWebUrl, // 이동시킬 페이지
           webUrl: staticWebUrl,
@@ -85,10 +84,10 @@ const SNSSharingComponent = ({ isOpen, onClose, imageUrl }: any) => {
       },
       buttons: [
         {
-          title: 'MARC로 이동', // 버튼 텍스트
+          title: '해양 생물 지도 보러 가기', // 버튼 텍스트
           link: {
-            mobileWebUrl: staticWebUrl, // 버튼이 이동시킬 페이지
-            webUrl: staticWebUrl,
+            mobileWebUrl: staticWebUrl + '/map', // 버튼이 이동시킬 페이지
+            webUrl: staticWebUrl + '/map',
           },
         },
       ],


### PR DESCRIPTION
공유 기능이 두 곳(리포트끝, 포스트)에서 가능하기 때문에 장소에 따라 피드의 제목과 내용을 수정했습니다.
- 추가된 props title<string> = 공유된 피드의 제목
value<string> = 공유된 피드의 내용

### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

fix/share

### 변경 사항


### 테스트 결과

